### PR TITLE
Added auto pairing of brackets/quotes, Fixes #51

### DIFF
--- a/lib/editor/pairer.dart
+++ b/lib/editor/pairer.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/services.dart';
+
+class CharacterPair implements TextInputFormatter {
+
+  /// All the characters that can be paired, and their pairing character.
+  static const PAIRED_CHARACTERS = {
+    '"': '"',
+    "'": "'",
+    '(': ')',
+    '{': '}',
+    '[': ']',
+    '`': '`'
+  };
+
+  final bool enablePairing;
+
+  /// Creates a CharacterPair with the ability to toggle it on/off with
+  /// [enablePairing] which should be derived from the settings. This is final
+  /// as a new instance is created when the note is navigated to again.
+  CharacterPair(this.enablePairing);
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    if (enablePairing) {
+      var keyPressed = KeyPressUtils.getPressedKey(oldValue, newValue).trim();
+      if (PAIRED_CHARACTERS.containsKey(keyPressed)) {
+        return pairCharacter(keyPressed, oldValue, newValue);
+      }
+    }
+
+    return newValue;
+  }
+
+  /// Pairs a character with the first character being [char] and the second
+  /// corresponding to its value in [PAIRED_CHARACTERS]. Takes in the same
+  /// [oldValue] and [newValue] as [formatEditUpdate] does. Does not do
+  /// any checking if the pairing _should_ happen, that is left to its invoker.
+  TextEditingValue pairCharacter(
+      String char, TextEditingValue oldValue, TextEditingValue newValue) {
+    var oldSelection = oldValue.selection;
+
+    final before = oldValue.text.substring(0, oldSelection.start);
+    final content = oldValue.text.substring(oldSelection.start, oldSelection.end);
+    final after = oldValue.text.substring(oldSelection.end);
+
+    var newSelection = TextSelection(
+        baseOffset: oldSelection.baseOffset + 1,
+        extentOffset: oldSelection.extentOffset + 1,
+        affinity: oldSelection.affinity,
+        isDirectional: oldSelection.isDirectional);
+
+    return TextEditingValue(
+        text: '$before$char$content${PAIRED_CHARACTERS[char]}$after',
+        selection: newSelection,
+        composing: oldValue.composing);
+  }
+}
+
+class KeyPressUtils {
+  static const BACKSPACE = '\u0008';
+
+  /// Gets the pressed key from the new and old values.
+  /// Adapted from rich_editable_code's KeyboardUtilz.getPressedKey
+  static String getPressedKey(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.length == 1 && newValue.text == '\n') {
+      return '\n';
+    }
+
+    var newSelection = newValue.selection;
+    var currentSelection = oldValue.selection;
+
+    if (currentSelection.baseOffset > newSelection.baseOffset) {
+      //backspace was pressed
+      return BACKSPACE;
+    }
+
+    return newValue.text
+        .substring(currentSelection.baseOffset, newSelection.baseOffset);
+  }
+}

--- a/lib/page/edit.dart
+++ b/lib/page/edit.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:app/editor/pairer.dart';
 import 'package:app/editor/syntax_highlighter.dart';
 import 'package:app/main.dart';
 import 'package:file_picker/file_picker.dart';
@@ -572,7 +573,7 @@ class _EditPageState extends State<EditPage> {
                       : Column(
                           children: <Widget>[
                             Expanded(
-                              /* 
+                              /*
                           fit: FlexFit.tight, */
                               child: Scrollbar(
                                 child: SingleChildScrollView(
@@ -590,6 +591,7 @@ class _EditPageState extends State<EditPage> {
                                           color: Theme.of(context)
                                               .colorScheme
                                               .onSurface),
+                                      inputFormatters: [CharacterPair(PrefService.getBool('editor_pair_brackets') ?? false)],
                                       textCapitalization:
                                           TextCapitalization.sentences,
                                       decoration: null,
@@ -625,7 +627,7 @@ class _EditPageState extends State<EditPage> {
                                 color: Colors.transparent,
                                 child: Row(
                                   children: <Widget>[
-                                    /* 
+                                    /*
                                 if (history.isNotEmpty) */
                                     Flexible(
                                       fit: FlexFit.tight,

--- a/lib/page/settings.dart
+++ b/lib/page/settings.dart
@@ -29,6 +29,7 @@ class _SettingsPageState extends State<SettingsPage> {
       'theme': 'light',
       'search_content': true,
       'editor_mode_switcher': true,
+      'editor_pair_brackets': true,
       'notes_list_virtual_tags': false,
       'debug_logs_sync': false,
       'editor_auto_save': false,
@@ -197,6 +198,10 @@ class _SettingsPageState extends State<SettingsPage> {
         SwitchPreference(
           'Use Mode Switcher',
           'editor_mode_switcher',
+        ),
+        SwitchPreference(
+          'Pair Brackets/Quotes',
+          'editor_pair_brackets',
         ),
         PreferenceTitle('Search'),
         SwitchPreference(

--- a/lib/page/settings.dart
+++ b/lib/page/settings.dart
@@ -29,7 +29,7 @@ class _SettingsPageState extends State<SettingsPage> {
       'theme': 'light',
       'search_content': true,
       'editor_mode_switcher': true,
-      'editor_pair_brackets': true,
+      'editor_pair_brackets': false,
       'notes_list_virtual_tags': false,
       'debug_logs_sync': false,
       'editor_auto_save': false,


### PR DESCRIPTION
This allows the user to enable in the settings auto-pairing of a few commonly paired characters,  **" ' ( { [ \`**
This provides a "Pair Brackets/Quotes" option in the settings to toggle this ability. It works with just typing the character and selecting a word, and pressing the for example the **"**, for the selection to be surrounded in quotes.